### PR TITLE
feat: add validator configuration, prepare jwt

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,14 +17,19 @@ module.exports = (params = {}) => {
                 document: null, // swagger document, path to swagger document or a function
                 // middleware options
                 middleware: {
+                    wrapper: {},
                     cors: {},
                     formParser: {},
                     bodyParser: {},
-                    validator: {},
+                    validator: {
+                        request: true,
+                        response: true
+                    },
                     swaggerUI: {
                         pathRoot: '/docs',
                         skipPaths: []
                     },
+                    jwt: false,
                     router: {}
                 },
                 // http server connection options

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -24,6 +24,10 @@ module.exports = [ // middleware order
         factory: require('./swaggerUI')
     },
     {
+        name: 'jwt',
+        factory: require('./jwt')
+    },
+    {
         name: 'router',
         factory: require('./router')
     }

--- a/middleware/jwt/index.js
+++ b/middleware/jwt/index.js
@@ -1,0 +1,4 @@
+const jwt = require('koa-jwt');
+module.exports = ({options}) => {
+    return jwt(options);
+};

--- a/middleware/validator/custom/index.js
+++ b/middleware/validator/custom/index.js
@@ -1,6 +1,6 @@
 
 const compile = require('./compile');
-module.exports = async ({port, swaggerDocument}) => {
+module.exports = async ({port, swaggerDocument, options}) => {
     const compiled = await compile(swaggerDocument);
     return async (ctx, next) => {
         if (!ctx.path.startsWith(swaggerDocument.basePath)) {
@@ -11,29 +11,36 @@ module.exports = async ({port, swaggerDocument}) => {
             ctx.status = 404;
             throw port.errors['swagger.requestValidation']();
         }
-        let errors = await validate.request({
-            query: ctx.request.query,
-            body: ctx.request.body,
-            files: ctx.request.files,
-            headers: ctx.request.headers,
-            params: ctx.params
-        });
-        if (errors.length > 0) {
-            ctx.status = 400;
-            let error = port.errors['swagger.requestValidation']({errors});
-            ctx.body = {error};
-            throw error;
+        let errors = [];
+        if (options.request) {
+            errors = await validate.request({
+                query: ctx.request.query,
+                body: ctx.request.body,
+                files: ctx.request.files,
+                headers: ctx.request.headers,
+                params: ctx.params
+            });
+            if (errors.length > 0) {
+                ctx.status = 400;
+                let error = port.errors['swagger.requestValidation']({errors});
+                ctx.body = {error};
+                throw error;
+            }
         }
+
         await next();
-        errors = await validate.response({
-            status: ctx.status,
-            body: ctx.body
-        });
-        if (errors.length > 0) {
-            ctx.status = 500;
-            let error = port.errors['swagger.responseValidation']({errors});
-            ctx.body = {error};
-            throw error;
+
+        if (options.response) {
+            errors = await validate.response({
+                status: ctx.status,
+                body: ctx.body
+            });
+            if (errors.length > 0) {
+                ctx.status = 500;
+                let error = port.errors['swagger.responseValidation']({errors});
+                ctx.body = {error};
+                throw error;
+            }
         }
     };
 };

--- a/middleware/wrapper/index.js
+++ b/middleware/wrapper/index.js
@@ -1,4 +1,4 @@
-module.exports = ({port}) => {
+module.exports = () => {
     return async (ctx, next) => {
         // request
         try {

--- a/package.json
+++ b/package.json
@@ -30,11 +30,12 @@
     "ut-tools": "^5.32.10"
   },
   "dependencies": {
-    "ajv": "^6.5.1",
     "@koa/cors": "^2.2.1",
+    "ajv": "^6.5.1",
     "koa": "^2.5.1",
     "koa-bodyparser": "^4.2.1",
     "koa-compose": "^4.1.0",
+    "koa-jwt": "^3.3.2",
     "koa-router": "^7.4.0",
     "koa-send": "^4.1.3",
     "koa2-formidable": "^1.0.2",


### PR DESCRIPTION
Features included:
* validator middleware now has configuration options - request and response (booleans indicating whether request and/or response should be validated)
* jwt middleware is prepared (disabled by default)