### PR TITLE
fix: jwt formatting plus audit and report fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,11 +272,40 @@ TO DO: `bodyParser` middleware description
 This middleware lets you authenticate HTTP requests
 using JSON Web Tokens in your application.
 
-If the token gets successfully validated
-then the payload will be accessible
-through the `$meta.auth` property.
-
 If the token is not valid then an error will be thrown.
+
+If the token gets successfully validated
+then the `$meta.auth` property will be populated
+with fields extracted from token's payload.
+
+`$meta.auth` is represented by a normalized
+data structure no matter what identity provider
+had generated the token.
+This is achieved by the concept of `formatters`.
+Currently only `keycloak` format is supported
+but more formats can be added in the long term
+in case any need for that arises. The formatter
+is set via the `format` property
+(see the examples below). It should be either
+a string or a function. If a string then a
+predefined formatter will be used (an error will
+be thrown if no matching formatter is found). If
+a custom function is provided then it will be
+called with jwt's body for each incoming HTTP request.
+The standard `$meta.auth` content format is:
+
+```js
+{
+    businessUnitId: 'businessUnitId', // null if no info
+    businessUnitName: 'businessUnitName', // null if no info
+    tenantId: 'tenantId', // null if no info
+    tenantName: 'tenantName', // null if no info
+    userId: 'userId', // null if no info
+    username: 'username', // null if no info
+    roles: ['role1', 'role2'] // empty array if no info
+}
+
+```
 
 #### configuration examples
 
@@ -287,7 +316,8 @@ Using a symetric key:
     "swagger": {
       "middleware": {
         "jwt": {
-          "secret": "secret"
+          "secret": "secret",
+          "format": "keycloak"
         }
       }
     }
@@ -303,7 +333,8 @@ You can specify audience and/or issuer as well:
         "jwt": {
           "secret": "secret",
           "audience": "http://myapi/protected",
-          "issuer": "http://issuer"
+          "issuer": "http://issuer",
+          "format": "keycloak"
         }
       }
     }
@@ -317,7 +348,8 @@ You can also specify an array of secrets.
     "swagger": {
       "middleware": {
         "jwt": {
-          "secret": ["oldSecret", "newSecret"]
+          "secret": ["oldSecret", "newSecret"],
+          "format": "keycloak"
         }
       }
     }
@@ -336,7 +368,8 @@ This middleware also supports verification via public keys
     swagger: {
       middleware: {
         jwt: {
-          secret: publicKey
+          secret: publicKey,
+          format: 'keycloak'
         }
       }
     }
@@ -367,7 +400,8 @@ For example:
           "cacheMaxAge": 86400000
         },
         "audience": "some-audience",
-        "issuer": "http://host:port/auth/realms/Test"
+        "issuer": "http://host:port/auth/realms/Test",
+        "format": "keycloak"
       }
     }
   }

--- a/errors.json
+++ b/errors.json
@@ -8,5 +8,6 @@
     "swagger.validationNotFound": "Validation not found",
     "swagger.requestValidation": "Request validation error",
     "swagger.responseValidation": "Response validation error",
-    "swagger.contextProviderError": "Context provider error"
+    "swagger.contextProviderError": "Context provider error",
+    "swagger.jwtFormatError": "JWT format error"
 }

--- a/middleware/audit/index.js
+++ b/middleware/audit/index.js
@@ -17,6 +17,13 @@ const getAuditHandler = (port, { namespace, exchange, routingKey, options }) => 
     return async(ctx, error) => {
         if (!ctx.ut.method) return; // audit bus methods only
 
+        const {
+            username: userName = null,
+            userId = null,
+            businessUnitId = null,
+            businessUnitName = null
+        } = ctx.ut.$meta.auth || {};
+
         const payload = {
             auditEntryId: null,
             dateAndTime: null,
@@ -39,10 +46,10 @@ const getAuditHandler = (port, { namespace, exchange, routingKey, options }) => 
             controllerName: ctx.ut.method.split('.')[0],
             controllerVersion: '0.0.1',
             channel: 'web',
-            userId: null,
-            userName: 'anonymousUser',
-            businessUnitName: null,
-            businessUnitId: null,
+            userId,
+            userName,
+            businessUnitName,
+            businessUnitId,
             severityLevel: null,
             sessionId: null,
             sourceIpAddress: '0:0:0:0:0:0:0:1',

--- a/middleware/jwt/format/keycloak.js
+++ b/middleware/jwt/format/keycloak.js
@@ -1,0 +1,64 @@
+/* example
+{
+  "jti": "0074de91-bb79-4fbd-8770-2ad04e9d67b3",
+  "exp": 1562850138,
+  "nbf": 0,
+  "iat": 1562849838,
+  "iss": "http://192.168.133.220:9120/auth/realms/Test",
+  "aud": "account",
+  "sub": "fe3c6c3f-c166-47a3-96d2-22d07463ed63",
+  "typ": "Bearer",
+  "azp": "allianz",
+  "auth_time": 0,
+  "session_state": "74d6ed56-c229-4105-afe5-1e61f9fb3b7c",
+  "acr": "1",
+  "realm_access": {
+    "roles": [
+      "Test",
+      "Test Sub",
+      "offline_access",
+      "Super Admin",
+      "uma_authorization",
+      "Mobile",
+      "customer"
+    ]
+  },
+  "resource_access": {
+    "account": {
+      "roles": [
+        "manage-account",
+        "manage-account-links",
+        "view-profile"
+      ]
+    }
+  },
+  "scope": "profile email",
+  "businessUnitName": null,
+  "email_verified": false,
+  "tenantName": "Test",
+  "tenantId": "Test",
+  "preferred_username": "stamen",
+  "businessUnitId": null
+}
+*/
+module.exports = ({
+    realm_access: {
+        roles = []
+    },
+    businessUnitId = null,
+    businessUnitName = null,
+    tenantId = null,
+    tenantName = null,
+    preferred_username: username = null,
+    sub: userId = null
+}) => {
+    return {
+        businessUnitId,
+        businessUnitName,
+        tenantId,
+        tenantName,
+        userId,
+        username,
+        roles
+    };
+};

--- a/middleware/jwt/index.js
+++ b/middleware/jwt/index.js
@@ -1,18 +1,39 @@
 const jwt = require('koa-jwt');
 const koaCompose = require('koa-compose');
 const { koaJwtSecret } = require('jwks-rsa');
-module.exports = ({options}) => {
-    const { key = 'user', jwks } = options;
-    if (jwks) {
-        options.secret = koaJwtSecret(jwks);
+const formats = {
+    keycloak: require('./format/keycloak')
+};
+module.exports = ({port, options}) => {
+    const { key = 'user' } = options;
+
+    let normalize = x => x;
+
+    if (options.format) {
+        if (typeof options.format === 'function') {
+            normalize = options.format;
+        } else {
+            normalize = formats[options.format];
+        }
+        if (typeof normalize !== 'function') throw new Error(`Unsupported jwt format: ${options.format}`);
+        delete options.format;
+    }
+
+    if (options.jwks) {
+        options.secret = koaJwtSecret(options.jwks);
         delete options.jwks;
     }
+
     return koaCompose([
         jwt(options).unless({
             custom: ctx => typeof ctx.ut.method === 'undefined'
         }),
         (ctx, next) => {
-            ctx.ut.$meta.auth = ctx.state[key];
+            try {
+                ctx.ut.$meta.auth = normalize(ctx.state[key]);
+            } catch (e) {
+                throw port.errors['swagger.jwtFormatError'](e);
+            }
             return next();
         }
     ]);

--- a/middleware/report/index.js
+++ b/middleware/report/index.js
@@ -30,8 +30,9 @@ const getReportHandler = (port, { namespace, exchange, routingKey, options, serv
             objectId = 'request.msg.id'
         } = data;
         const handler = handlers[method] = async ctx => {
+            const { tenantId = null } = ctx.ut.$meta.auth || {};
             const payload = {
-                tenantId: service, // TODO: send correct tenantId when ready
+                tenantId,
                 objectId: dotProp.get({request: ctx.ut, response: ctx.body}, objectId),
                 service,
                 eventType,


### PR DESCRIPTION
fixes included:
* jwt 'formatters' concept has been adopted in order to achieve $meta.auth content normalization
* audit username, userId, businessUnitId and businessUnitName fields get populated
* report tenantId field get populated
* extra error handling has been applied
* documentation has been extended accordingly
