### PR TITLE
fix: share entire contcontext in meta

### DIFF
--- a/middleware/router/index.js
+++ b/middleware/router/index.js
@@ -38,7 +38,7 @@ module.exports = ({port, options}) => {
                     trace: ctx.request.headers['x-trace'] || uuid.v4(),
                     method: operationId,
                     headers: ctx.request.headers,
-                    ctx
+                    rawBody: ctx.request.rawBody
                 };
                 return next();
             });

--- a/middleware/router/index.js
+++ b/middleware/router/index.js
@@ -38,6 +38,7 @@ module.exports = ({port, options}) => {
                     trace: ctx.request.headers['x-trace'] || uuid.v4(),
                     method: operationId,
                     headers: ctx.request.headers,
+                    path: ctx.path,
                     rawBody: ctx.request.rawBody
                 };
                 return next();

--- a/middleware/router/index.js
+++ b/middleware/router/index.js
@@ -37,7 +37,8 @@ module.exports = ({port, options}) => {
                     mtid: 'request',
                     trace: ctx.request.headers['x-trace'] || uuid.v4(),
                     method: operationId,
-                    headers: ctx.request.headers
+                    headers: ctx.request.headers,
+                    ctx
                 };
                 return next();
             });


### PR DESCRIPTION
needed for custom logic that is needed for trace raw request, coming from tcp stack directly.
for instance, http-sign