### PR TITLE
feat: provide possibility to serve static files

### DIFF
--- a/errors.json
+++ b/errors.json
@@ -11,5 +11,6 @@
     "swagger.contextProviderError": "Context provider error",
     "swagger.jwtFormatError": "JWT format error",
     "swagger.authorizationError": "Authorization error",
-    "swagger.securityViolation": "Security violation error"
+    "swagger.securityViolation": "Security violation error",
+    "swagger.unsupportedUrlProtocol": "Unsupported url protocol {protocol}"
 }

--- a/middleware/requestHandler/index.js
+++ b/middleware/requestHandler/index.js
@@ -90,6 +90,11 @@ module.exports = ({port, options}) => {
 
                     switch (mtid) {
                         case 'response':
+                            if (typeof response === 'string') {
+                                try {
+                                    response = new URL(response);
+                                } catch (e) {}
+                            }
                             if (response instanceof URL) {
                                 switch (response.protocol) {
                                     case 'file:': {
@@ -123,10 +128,10 @@ module.exports = ({port, options}) => {
                                 cause: response
                             });
                     }
-                    resolve(next);
                 } catch (e) {
                     reject(e);
                 }
+                resolve(next);
             };
             port.stream.push([transformRequest(message, $meta), $meta]);
         });

--- a/middleware/requestHandler/index.js
+++ b/middleware/requestHandler/index.js
@@ -1,4 +1,7 @@
 const defaultTransform = x => x;
+const send = require('koa-send');
+const url = require('url');
+const { parse } = require('path');
 module.exports = ({port, options}) => {
     const {
         authorize,
@@ -74,30 +77,55 @@ module.exports = ({port, options}) => {
                 break;
         }
         return new Promise((resolve, reject) => {
-            $meta.reply = (response, $meta) => {
-                const {responseHeaders, cookies, mtid} = $meta;
-                if (responseHeaders) {
-                    Object.keys(responseHeaders).forEach(header => {
-                        ctx.set(header, responseHeaders[header]);
-                    });
-                }
+            $meta.reply = async(response, $meta) => {
+                try {
+                    const {responseHeaders, cookies, mtid} = $meta;
+                    if (responseHeaders) {
+                        Object.keys(responseHeaders).forEach(header => {
+                            ctx.set(header, responseHeaders[header]);
+                        });
+                    }
 
-                if (Array.isArray(cookies)) cookies.forEach(cookie => ctx.cookies.set(...cookie));
+                    if (Array.isArray(cookies)) cookies.forEach(cookie => ctx.cookies.set(...cookie));
 
-                switch (mtid) {
-                    case 'response':
-                        ctx.body = transformResponse(response, $meta);
-                        ctx.status = successCode;
-                        return resolve(next());
-                    case 'error':
-                        response = transformErrorResponse(response);
-                        ctx.status = (response.details && response.details.statusCode) || 400;
-                        return reject(response);
-                    default:
-                        ctx.status = 400;
-                        return reject(port.errors.swagger({
-                            cause: response
-                        }));
+                    switch (mtid) {
+                        case 'response':
+                            if (response instanceof URL) {
+                                switch (response.protocol) {
+                                    case 'file:': {
+                                        const filePath = url.fileURLToPath(response);
+                                        const options = {...$meta.options};
+                                        if (!options.root) options.root = parse(filePath).root;
+                                        await send(ctx, filePath, options);
+                                    } break;
+                                    default:
+                                        throw port.errors['swagger.unsupportedUrlProtocol']({
+                                            params: {
+                                                protocol: response.protocol
+                                            }
+                                        });
+                                }
+                            } else {
+                                ctx.body = transformResponse(response, $meta);
+                                ctx.status = successCode;
+                            }
+                            break;
+                        case 'error':
+                            response = transformErrorResponse(response);
+                            ctx.status = (response.details && response.details.statusCode) || 400;
+                            if (response instanceof Error) throw response;
+                            throw port.errors.swagger({
+                                cause: response
+                            });
+                        default:
+                            ctx.status = 400;
+                            throw port.errors.swagger({
+                                cause: response
+                            });
+                    }
+                    resolve(next);
+                } catch (e) {
+                    reject(e);
                 }
             };
             port.stream.push([transformRequest(message, $meta), $meta]);


### PR DESCRIPTION
provide possibility to serve static files

example:

In swagger:
```json
"/test": {
    "get": {
        "summary": "returns static resource",
        "operationId": "test.file.get",
        "produces": [ "application/pdf" ],
        "responses": {
            "200": {
                "description": "OK",
                "schema": {
                    "type": "object"
                }
            }
        }
    }
}
```

in code:
```js
'test.file.get': (msg, $meta) => {
    const url = require('url');
    return new URL(url.pathToFileURL('temp.pdf'));
}
```

